### PR TITLE
Bigleague.toml: add config file

### DIFF
--- a/Bigleague.toml
+++ b/Bigleague.toml
@@ -1,3 +1,7 @@
+[web]
+ip = "127.0.0.1"
+port = 8000
+
 [stats]
 rosters_interval = 600
 players_interval = 172800
@@ -6,8 +10,13 @@ leagues_interval = 600
 
 [database]
 host = "0.0.0.0"
-port = "5432"
+port = 5432
+user = "admin"
 password = "password"
+dbname = "test"
+max_open = 32
+max_idle = 8
+timeout = 15
 
 [bigleague]
 leagues = [

--- a/Bigleague.toml
+++ b/Bigleague.toml
@@ -1,0 +1,19 @@
+[stats]
+rosters_interval = 600
+players_interval = 172800
+users_interval = 600
+leagues_interval = 600
+
+[database]
+host = "0.0.0.0"
+port = "5432"
+password = "password"
+
+[bigleague]
+leagues = [
+    "853520029218607104",
+    "958098050679967744",
+    "871112580960231424",
+]
+playoff_teams = 8
+playoff_start_week = 14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,7 +465,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -471,6 +477,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "headers"
@@ -658,7 +670,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1394,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
@@ -1720,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1732,20 +1754,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 warp = "0.3.5"
 reqwest = { version = "0.11.18", features = ["blocking"] }
-toml = "0.7.4"
+toml = "0.7.6"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
 tokio = { version = "1.28.2", features = ["macros"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,12 @@
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Web {
+    pub ip: String,
+    pub port: u16,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Stats {
     pub rosters_interval: i32,
     pub players_interval: i32,
@@ -8,22 +14,28 @@ pub struct Stats {
     pub leagues_interval: i32,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Database {
     pub host: String,
-    pub port: Option<String>,
+    pub port: Option<u16>,
+    pub user: String,
     pub password: String,
+    pub dbname: String,
+    pub max_open: u64,
+    pub max_idle: u64,
+    pub timeout: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Bigleague {
     pub leagues: Vec<String>,
     pub playoff_teams: i32,
     pub playoff_start_week: i32,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Config {
+    pub web: Web,
     pub stats: Stats,
     pub database: Database,
     pub bigleague: Bigleague,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,35 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Stats {
+    pub rosters_interval: i32,
+    pub players_interval: i32,
+    pub users_interval: i32,
+    pub leagues_interval: i32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Database {
+    pub host: String,
+    pub port: Option<String>,
+    pub password: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Bigleague {
+    pub leagues: Vec<String>,
+    pub playoff_teams: i32,
+    pub playoff_start_week: i32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Config {
+    pub stats: Stats,
+    pub database: Database,
+    pub bigleague: Bigleague,
+}
+
+pub fn read_config(path: &str) -> Result<Config, toml::de::Error> {
+    let raw_config = std::fs::read_to_string(path).expect("Can't find config file");
+    toml::from_str(&raw_config)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::convert::Infallible;
 mod db;
 mod stats;
 mod handlers;
+mod config;
 
 fn with_tera(tera: Arc<Tera>) -> impl Filter<Extract = (Arc<Tera>,), Error = Infallible> + Clone {
     warp::any().map(move || tera.clone())
@@ -13,11 +14,9 @@ fn with_tera(tera: Arc<Tera>) -> impl Filter<Extract = (Arc<Tera>,), Error = Inf
 
 #[tokio::main]
 async fn main() {
-    let league_ids = vec![
-        "853520029218607104".to_string(),
-        "958098050679967744".to_string(),
-        "871112580960231424".to_string(),
-    ];
+
+    let config: config::Config = config::read_config("Bigleague.toml").expect("Couldn't parse config file");
+    let league_ids = config.bigleague.leagues;
 
     let pool = db::create_pool().unwrap();
     println!("Creating tables...");   
@@ -35,7 +34,7 @@ async fn main() {
     // Be careful with fetch players in the future.
     // Temporarily reading from json file, but
     // the call to the Sleeper API is large
-    stats::fetch_players(&pool).await.unwrap();
+    // stats::fetch_players(&pool).await.unwrap();
 
     let mut tera: Tera = Tera::new("templates/**/*").unwrap();
     let tera: Arc<Tera> = Arc::new(tera);


### PR DESCRIPTION
Bigleague.toml is added to provide a configuration file for the server. Adds options to change the database details, warp HTTP ip and port, and others. See the Bigleague.toml file for the full list. It currently includes fields for future features, `[stats]` in particular. There are currently no optional fields.