### PR TITLE
usable leagues page

### DIFF
--- a/Bigleague.toml
+++ b/Bigleague.toml
@@ -3,10 +3,10 @@ ip = "127.0.0.1"
 port = 8000
 
 [stats]
-rosters_interval = 600
+rosters_interval = 3000
 players_interval = 172800
-users_interval = 600
-leagues_interval = 600
+users_interval = 3000
+leagues_interval = 3000
 dev_mode = true
 players_path = "data/players.json"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -20,6 +20,7 @@ pub type DBPool = Pool<PgConnectionManager<NoTls>>;
 pub struct Standing {
     pub user: User,
     pub roster: Roster,
+    pub league: League,
     pub rank: i64,
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,7 +5,7 @@ use std::convert::Infallible;
 use std::error::Error;
 use tokio::time;
 use std::sync::Arc;
-use log::info;
+use log::{info, warn};
 
 use crate::config;
 
@@ -17,7 +17,11 @@ pub async fn stats_loop(config: config::Config, db_pool: Arc<db::DBPool>) -> Res
         Some(m) => m,
         None => false,
     };
-    
+
+    if dev_mode {
+        warn!("running in dev mode");
+    }
+
     let players_path = match config.clone().stats.players_path {
         Some(p) => p,
         None => {

--- a/templates/league.html
+++ b/templates/league.html
@@ -1,7 +1,34 @@
+<!DOCTYPE html>
 <html>
     {% include "header.html" %}
-    <img src="https://sleepercdn.com/avatars/{{ league.avatar }}" alt="League Avatar" />
-    <h1>{{ league.name }}</h1>
-    <h3>{{ league.id }}</h3>
+    <div>
+        <h1 class="is-center">{{ league.name }}</h1>
+        <div>
+            <table>
+                <thead>
+                    <tr>
+                        <th>rank</th>
+                        <th></th>
+                        <th>name</th>
+                        <th>wins</th>
+                        <th>losses</th>
+                        <th>points for</th>
+                        <th>points against</th>
+                    </tr>
+                </thead>
+                {% for s in standings -%}
+                <tr>
+                    <td>{{ s.rank }}</td>
+                    <td><img class="standing-avatar" src="https://sleepercdn.com/avatars/{{ s.user.avatar }}" /></td>
+                    <td><a href="/user/{{ s.user.id }}">{{ s.user.name }}</a></td>
+                    <td>{{ s.roster.wins }}</td>
+                    <td>{{ s.roster.losses }}</td>
+                    <td>{{ s.roster.fpts }}.{{ s.roster.fpts_decimal }}</td>
+                    <td>{{ s.roster.fpts_against }}.{{ s.roster.fpts_against_decimal }}</td>
+                </tr>
+                {%- endfor %}
+            </table>
+        </div>
+    </div>
     {% include "footer.html" %}
-</html
+</html>

--- a/templates/standings.html
+++ b/templates/standings.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     {% include "header.html" %}
     <div>
@@ -12,6 +13,7 @@
                         <th>losses</th>
                         <th>points for</th>
                         <th>points against</th>
+                        <th>league</th>
                     </tr>
                 </thead>
                 {% for s in standings -%}
@@ -23,6 +25,7 @@
                     <td>{{ s.roster.losses }}</td>
                     <td>{{ s.roster.fpts }}.{{ s.roster.fpts_decimal }}</td>
                     <td>{{ s.roster.fpts_against }}.{{ s.roster.fpts_against_decimal }}</td>
+                    <td><a href="/league/{{ s.league.id }}">{{ s.league.name }}</a></td>
                 </tr>
                 {%- endfor %}
             </table>

--- a/templates/user.html
+++ b/templates/user.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     {% include "header.html" %}
     <div class="row is-center">


### PR DESCRIPTION
Fixes the defunct league page. You can now see which user is in which league, and view the league by clicking on the name. This takes you to the league page which displays all the teams which are a member of the league.