### PR TITLE
many more stats for the NFL State, player scoring and matchups

### DIFF
--- a/Bigleague.toml
+++ b/Bigleague.toml
@@ -7,6 +7,8 @@ rosters_interval = 3000
 players_interval = 172800
 users_interval = 3000
 leagues_interval = 3000
+state_interval = 3000
+matchups_interval = 3000
 dev_mode = true
 players_path = "data/players.json"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ pub struct Stats {
     pub players_interval: u64,
     pub users_interval: u64,
     pub leagues_interval: u64,
+    pub state_interval: u64,
+    pub matchups_interval: u64,
     pub dev_mode: Option<bool>,
     pub players_path: Option<String>,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -42,6 +42,7 @@ pub struct Roster {
     pub fpts_decimal: i32,
     pub fpts_against: i32,
     pub fpts_against_decimal: i32,
+    pub roster_id: i32,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -140,7 +141,8 @@ pub async fn create_tables(db_pool: Arc<DBPool>) -> Result<()>{
             fpts integer NOT NULL,
             fpts_decimal integer NOT NULL,
             fpts_against integer NOT NULL,
-            fpts_against_decimal integer NOT NULL
+            fpts_against_decimal integer NOT NULL,
+            roster_id integer NOT NULL
         )
         "
     ).await.unwrap();

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -29,7 +29,7 @@ pub async fn league_handler(id: String, db_pool: Arc<db::DBPool>, tera: Arc<Tera
         avatar: rows[0].get(2),
     };
 
-    let rows = db.query("SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY wins DESC, fpts DESC, fpts_decimal DESC, fpts_against DESC, fpts_against_decimal DESC) as rank FROM users, rosters, leagues WHERE users.id = rosters.user_id AND leagues.id = rosters.league_id) as league_standings WHERE league_standings.league_id = $1", &[&idstr])
+    let rows = db.query("SELECT * FROM users, rosters, leagues, ranks WHERE users.id = rosters.user_id AND leagues.id = rosters.league_id AND ranks.user_id = users.id AND leagues.id = $1 ORDER BY ranks.rank ASC", &[&idstr])
         .await
         .unwrap();
 
@@ -118,7 +118,7 @@ pub async fn standings_handler(db_pool: Arc<db::DBPool>, tera: Arc<Tera>) -> std
     let db = db::get_db_con(&db_pool)
             .await;
 
-    let rows = db.query("SELECT *, ROW_NUMBER() OVER (ORDER BY wins DESC, fpts DESC, fpts_decimal DESC, fpts_against DESC, fpts_against_decimal DESC) as rank FROM users, rosters, leagues WHERE users.id = rosters.user_id AND leagues.id = rosters.league_id", &[])
+    let rows = db.query("SELECT * FROM users, rosters, leagues, ranks WHERE users.id = rosters.user_id AND leagues.id = rosters.league_id AND ranks.user_id = users.id", &[])
         .await
         .unwrap();
 
@@ -157,7 +157,7 @@ fn collect_standings(rows: Vec<Row>) -> Vec<db::Standing> {
                 avatar: row.get(15),
             };
 
-            let rank: i64 = row.get(16);
+            let rank: i64 = row.get(17);
 
             db::Standing {
                 user,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -29,7 +29,7 @@ pub async fn league_handler(id: String, db_pool: Arc<db::DBPool>, tera: Arc<Tera
         avatar: rows[0].get(2),
     };
 
-    let rows = db.query("SELECT *, ROW_NUMBER() OVER (ORDER BY wins DESC, fpts DESC, fpts_decimal DESC, fpts_against DESC, fpts_against_decimal DESC) as rank FROM users, rosters, leagues WHERE users.id = rosters.user_id AND leagues.id = rosters.league_id AND rosters.league_id = $1", &[&idstr])
+    let rows = db.query("SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY wins DESC, fpts DESC, fpts_decimal DESC, fpts_against DESC, fpts_against_decimal DESC) as rank FROM users, rosters, leagues WHERE users.id = rosters.user_id AND leagues.id = rosters.league_id) as league_standings WHERE league_standings.league_id = $1", &[&idstr])
         .await
         .unwrap();
 
@@ -70,6 +70,7 @@ pub async fn user_handler(id: String, db_pool: Arc<db::DBPool>, tera: Arc<Tera>)
         fpts_decimal: row.get(9),
         fpts_against: row.get(10),
         fpts_against_decimal: row.get(11),
+        roster_id: row.get(12),
     };
 
     let player_rows = db.query(
@@ -147,15 +148,16 @@ fn collect_standings(rows: Vec<Row>) -> Vec<db::Standing> {
                 fpts_decimal: row.get(9),
                 fpts_against: row.get(10),
                 fpts_against_decimal: row.get(11),
+                roster_id: row.get(12),
             };
           
             let league = db::League {
-                id: row.get(12),
-                name: row.get(13),
-                avatar: row.get(14),
+                id: row.get(13),
+                name: row.get(14),
+                avatar: row.get(15),
             };
 
-            let rank: i64 = row.get(15);
+            let rank: i64 = row.get(16);
 
             db::Standing {
                 user,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -6,6 +6,7 @@ use std::error::Error;
 use tokio::time;
 use std::sync::Arc;
 use log::{info, warn};
+use std::collections::{HashMap, HashSet};
 
 use crate::config;
 
@@ -322,10 +323,146 @@ pub async fn fetch_players(db_pool: &db::DBPool, dev_mode: bool, players_path: S
 
 pub async fn fetch_state(db_pool: &db::DBPool) -> Result<(), Infallible> {
 
+    info!("fetching the state of the NFL");
+
+    let con = db::get_db_con(db_pool).await;
+
+    let body = reqwest::get("https://api.sleeper.app/v1/state/nfl")
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+    let state: Value = serde_json::from_str(&body).unwrap();
+
+    con.execute(
+        "
+        INSERT INTO state VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT(season, week) DO UPDATE SET
+            season = EXCLUDED.season,
+            week = EXCLUDED.week,
+            league_season = EXCLUDED.league_season,
+            display_week = EXCLUDED.display_week,
+            season_type = EXCLUDED.season_type
+            
+        ",
+        &[
+            &state["season"].as_str().unwrap_or("0").parse::<i32>().unwrap_or(0),
+            &i32::try_from(state["week"].as_u64().unwrap_or(0)).unwrap(),
+            &state["league_season"].as_str().unwrap_or("0").parse::<i32>().unwrap_or(0),
+            &i32::try_from(state["display_week"].as_u64().unwrap_or(0)).unwrap(),
+            &state["season_type"].as_str().unwrap_or("NA"),
+        ]
+    ).await.unwrap();
+
     Ok(())
 }
 
 pub async fn fetch_matchups(db_pool: &db::DBPool, league_id: String) -> Result<(), Infallible> {
 
+    info!("fetching matchups for league: {}", league_id);
+
+    let con = db::get_db_con(db_pool).await;
+
+    let time = con.query("SELECT season, week FROM state ORDER BY season DESC, week DESC LIMIT 1", &[])
+        .await
+        .unwrap();
+
+    let season: i32 = 2022;//time[0].get("season");
+    let week: i32 = 12;//time[0].get("week");
+
+    let body = reqwest::get(format!("https://api.sleeper.app/v1/league/{}/matchups/{}", league_id, week))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    let matchups: Vec<Value> = serde_json::from_str(&body).unwrap();
+
+    let roster_map_for_league: HashMap<i32, String> = 
+        con.query("
+            SELECT roster_id, user_id FROM rosters WHERE league_id = $1
+            ",
+            &[&league_id])
+        .await
+        .unwrap()
+        .iter()
+        .map(|row| (row.get("roster_id"), row.get("user_id")))
+        .collect();
+
+    let mut opponent_map: HashMap<String, String> = HashMap::new();
+    let mut opponent_resolutions: HashMap<u64, u64> = HashMap::new();
+    for matchup in matchups.clone() {
+        let m_id = matchup["matchup_id"].as_u64().unwrap();
+        let r_id = matchup["roster_id"].as_u64().unwrap();
+
+        if opponent_resolutions.contains_key(&m_id) {
+            let opponents = (
+                roster_map_for_league.get(&i32::try_from(r_id).unwrap()).unwrap(),
+                roster_map_for_league.get(
+                    &i32::try_from(
+                        *opponent_resolutions.get(&m_id).unwrap()
+                    ).unwrap()
+                ).unwrap(),
+            );
+            opponent_map.insert(opponents.0.to_string(), opponents.1.to_string());
+            opponent_map.insert(opponents.1.to_string(), opponents.0.to_string());
+        } else {
+            opponent_resolutions.insert(m_id, r_id);
+        }
+    }
+
+    for matchup in matchups {
+        let user = roster_map_for_league.get(
+            &i32::try_from(matchup["roster_id"].as_u64().unwrap()).unwrap()
+        ).unwrap();
+
+        con.execute(
+            "
+            INSERT INTO matchups VALUES ($1, $2, $3, $4, $5, $6)
+            ON CONFLICT(season, week, league_id, user_id, opponent_id) DO UPDATE SET
+                season = EXCLUDED.season,
+                week = EXCLUDED.week,
+                league_id = EXCLUDED.league_id,
+                user_id = EXCLUDED.user_id,
+                opponent_id = EXCLUDED.opponent_id,
+                points = EXCLUDED.points
+            ",
+            &[
+                &season,
+                &week,
+                &league_id,
+                user,
+                &opponent_map.get(
+                    user
+                ).unwrap(),
+                &(matchup["points"].as_f64().unwrap() as f32),
+            ]
+        ).await.unwrap();
+
+        for (player, points) in matchup["players_points"].as_object().unwrap() {
+            con.execute(
+            "
+            INSERT INTO scores VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT(player_id, league_id, season, week) DO UPDATE SET
+                player_id = EXCLUDED.player_id,
+                league_id = EXCLUDED.league_id,
+                season = EXCLUDED.season,
+                week = EXCLUDED.week,
+                points = EXCLUDED.points
+            ",
+            &[
+                player,
+                &league_id,
+                &season,
+                &week,
+                &(points.as_f64().unwrap() as f32),
+            ]
+        ).await.unwrap();
+    
+        }
+    } 
     Ok(())
 }


### PR DESCRIPTION
Adds stats to store the NFL state, matchups and player scoring for each week. It also creates a view to store user rankings instead of calculating each time the standings need to be shown.

Partially addresses #14, fully address #2, and we now have all the necessary stats to generate a bracket per #3.