### PR TITLE
resolve playoff bracket, very simple list bracket

### DIFF
--- a/Bigleague.toml
+++ b/Bigleague.toml
@@ -1,6 +1,6 @@
 [web]
-ip = "127.0.0.1"
-port = 8000
+ip = "0.0.0.0"
+port = 6543
 
 [stats]
 rosters_interval = 3000
@@ -24,5 +24,14 @@ timeout = 15
 
 [bigleague]
 leagues = []
-playoff_teams = 8
-playoff_start_week = 14
+playoffs_start_week = 10
+playoffs_championship_week = 12
+
+# Only one of the following playoff options are supported
+
+# Gives bids to the top teams regardless of which league they are in
+playoffs_at_large = { bids = 4 }
+
+# Gives bids to the top n teams in each league
+# This is currently unsupported!
+playoffs_per_league = { bids_per_league = 2 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,10 +31,22 @@ pub struct Database {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AtLarge {
+    pub bids: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PerLeague {
+    pub bids_per_league: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Bigleague {
     pub leagues: Vec<String>,
-    pub playoff_teams: i32,
-    pub playoff_start_week: i32,
+    pub playoffs_start_week: i32,
+    pub playoffs_championship_week: i32,
+    pub playoffs_at_large: Option<AtLarge>,
+    pub playoffs_per_league: Option<PerLeague>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,3 @@
-use serde_json::Result;
 use warp::Filter;
 use mobc::{Connection, Pool};
 use mobc_postgres::{tokio_postgres, PgConnectionManager};
@@ -8,7 +7,8 @@ use std::time::Duration;
 use std::convert::Infallible;
 use serde::{Serialize, Deserialize};
 use std::sync::Arc;
-use log::info;
+use std::collections::HashMap;
+use log::{info, error, trace};
 
 use crate::config;
 
@@ -45,7 +45,7 @@ pub struct Roster {
     pub roster_id: i32,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct User {
     pub id: String,
     pub name: String,
@@ -115,6 +115,22 @@ pub struct Week {
     pub opponent_points: f32,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Bracket {
+    pub num_teams: usize,
+    pub start_week: i32,
+    pub champ_week: i32,
+    pub stages: Vec<Vec<PlayoffTeam>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PlayoffTeam {
+    pub week: i32,
+    pub rank: i64,
+    pub user: User,
+    pub points: f32,
+}
+
 pub async fn get_db_con(db_pool: &DBPool) -> DBCon {
     db_pool.get().await.unwrap()
 }
@@ -145,7 +161,7 @@ pub fn create_pool(bl_config: config::Config) -> std::result::Result<DBPool, mob
             .build(manager))
 }
 
-pub async fn create_tables(db_pool: Arc<DBPool>) -> Result<()>{
+pub async fn create_tables(db_pool: Arc<DBPool>) -> Result<(), tokio_postgres::Error>{
 
     info!("creating tables");
 
@@ -265,4 +281,218 @@ pub async fn create_tables(db_pool: Arc<DBPool>) -> Result<()>{
         "
     ).await.unwrap();
     Ok(())
+}
+
+pub async fn get_num_leagues(con: DBCon) -> Result<i64, tokio_postgres::Error> {
+    Ok(
+        con.query(
+            "SELECT count(*) FROM leagues",
+            &[])
+        .await?[0]
+        .get::<usize, i64>(0))
+}
+
+pub async fn get_time_period(con: &DBCon) -> Result<(i32, i32), tokio_postgres::Error> {
+    let time = &con.query("
+            SELECT SEASON,
+                WEEK
+            FROM STATE
+            ORDER BY SEASON DESC,
+                WEEK DESC
+            LIMIT 1
+              ",
+              &[])
+        .await?[0];
+    Ok((time.get("season"), time.get("week")))
+}
+
+pub fn resolve_bracket(initial_round: Vec<PlayoffTeam>, start_week: i32, end_week: i32, weeks: HashMap<(i32, i64), f32>) -> Option<Vec<Vec<PlayoffTeam>>> {
+    let mut bracket = vec![initial_round.clone()];
+    let mut curr_round = initial_round.clone();
+    for r in start_week..end_week {
+        let next_round: Vec<PlayoffTeam> = curr_round
+            .chunks_exact(2)
+            .map(|matchup| {
+                let team1_pts = weeks.get(&(r, matchup[0].rank))?;
+                let team2_pts = weeks.get(&(r, matchup[1].rank))?;
+                trace!(
+                    "team1 ({:?}) = {}  vs  team2 ({:?}) = {}",
+                    matchup[0].user.name,
+                    team1_pts,
+                    matchup[1].user.name,
+                    team2_pts,
+                    );
+                if team1_pts > team2_pts {
+                    trace!("team1 ({:?}) wins!", matchup[0].user.name);
+                    Some(
+                        PlayoffTeam {
+                            week: r+1,
+                            points: *weeks.get(&(r+1, matchup[0].rank)).unwrap_or(&0.0),
+                            ..matchup[0].clone()
+                        }
+                    )
+                } else {
+                    trace!("team2 ({:?}) wins!", matchup[1].user.name);
+                    Some(
+                        PlayoffTeam {
+                            week: r+1,
+                            points: *weeks.get(&(r+1, matchup[1].rank)).unwrap_or(&0.0),
+                            ..matchup[1].clone()
+                        }
+                    )
+                }
+            })
+            .collect::<Option<Vec<PlayoffTeam>>>()?;
+
+        bracket.push(next_round.clone());
+        curr_round = next_round;
+    }
+
+    Some(bracket)
+}
+
+pub async fn get_bracket(con: DBCon, config: config::Config) -> Result<Bracket, tokio_postgres::Error>{
+
+    let start_week = config.bigleague.playoffs_start_week;
+    let champ_week = config.bigleague.playoffs_championship_week;
+    let bids = config.bigleague.playoffs_at_large.unwrap().bids;
+
+    let (curr_season, curr_week) = get_time_period(&con).await?;
+
+    let possible_user_weeks: Vec<PlayoffTeam> = con.query("
+            SELECT WEEK,
+                RANKS.RANK as RANK,
+                USERS.ID,
+                USERS.NAME,
+                USERS.AVATAR,
+                POINTS
+            FROM MATCHUPS,
+                RANKS,
+                USERS
+            WHERE WEEK >= $1
+                AND SEASON = $2
+                AND RANKS.USER_ID = MATCHUPS.USER_ID
+                AND RANKS.USER_ID = USERS.ID
+                AND RANKS.RANK <= $3
+            ORDER BY WEEK ASC, RANK ASC;
+              ",
+              &[&curr_week, &curr_season, &bids])
+        .await?
+        .into_iter()
+        .map(|row| {
+            PlayoffTeam {
+                week: row.get("week"),
+                rank: row.get("rank"),
+                user: User {
+                    id: row.get("id"),
+                    name: row.get("name"),
+                    avatar: row.get("avatar"),
+                },
+                points: row.get("points"),
+            }
+        })
+        .collect();
+
+    // week_rank: (week, rank) -> points
+    let week_rank: HashMap<(i32, i64), f32> = possible_user_weeks
+        .clone()
+        .into_iter()
+        .map(|user_week| ((user_week.week, user_week.rank), user_week.points))
+        .collect();
+
+    let base: Vec<PlayoffTeam> = possible_user_weeks
+        .into_iter()
+        .filter(|team| team.week == start_week)
+        .collect();
+
+    let top_half = base
+        .clone()
+        .into_iter()
+        .take((bids as usize)/2);
+
+    let bottom_half = base
+        .clone()
+        .into_iter()
+        .skip((bids as usize)/2)
+        .take((bids as usize)/2)
+        .rev();
+
+    let matched: Vec<PlayoffTeam> = top_half
+        .zip(bottom_half)
+        .map(|m| vec![m.0, m.1])
+        .flatten()
+        .collect();
+
+    let stages: Vec<Vec<PlayoffTeam>> = 
+        match resolve_bracket(
+            matched,
+            start_week,
+            if curr_week < start_week { start_week } else { curr_week },
+            week_rank
+        ) {
+            Some(s) => s,
+            None => {
+                error!("Couldn't resolve playoff bracket");
+                vec![]
+            },
+        };
+
+    Ok(
+        Bracket {
+            num_teams: base.len(),
+            start_week,
+            champ_week,
+            stages,
+        }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_resolve_small_bracket() {
+        let team1 = db::PlayoffTeam {
+            week: 0,
+            rank: 1,
+            user: db::User {
+                id: "1".to_string(),
+                name: "Todd".to_string(),
+                avatar: "cafed00d".to_string(),
+            },
+            points: 100.0,
+        };
+
+        let team2 = db::PlayoffTeam {
+            week: 0,
+            rank: 2,
+            user: db::User {
+                id: "1".to_string(),
+                name: "Eve".to_string(),
+                avatar: "deadbeef".to_string(),
+            },
+            points: 99.0,
+        };
+        
+        let matchups: HashMap<(i32, i64), f32> = HashMap::from([
+            ((0, 1), 100.0),
+            ((0, 2), 99.0),
+        ]);
+
+        let base = vec![team1.clone(), team2.clone()];
+        let resolved_bracket = db::resolve_bracket(base, 0, 1, matchups).unwrap();
+
+        assert_eq!(
+            resolved_bracket.into_iter().last().unwrap(),
+            vec![
+                db::PlayoffTeam {
+                    points: 0.0,
+                    week: 1,
+                    ..team1
+                }
+            ]
+            );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,10 @@ fn with_tera(tera: Arc<Tera>) -> impl Filter<Extract = (Arc<Tera>,), Error = Inf
     warp::any().map(move || tera.clone())
 }
 
+fn with_config(config: config::Config) -> impl Filter<Extract = (config::Config,), Error = Infallible> + Clone {
+    warp::any().map(move || config.clone())
+}
+
 #[tokio::main]
 async fn main() {
 
@@ -48,6 +52,7 @@ async fn main() {
     let standings_route = warp::path::end()
         .and(db::with_db(pool.clone()))
         .and(with_tera(tera.clone()))
+        .and(with_config(config.clone()))
         .and_then(handlers::standings_handler);
 
     let not_found_route = warp::any()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -130,7 +130,7 @@ pub async fn fetch_rosters(db_pool: &db::DBPool, league_id: String) -> Result<()
         .await
         .unwrap();
 
-    let roster_list: Vec<Value> = serde_json::from_str(&body).unwrap();
+    let roster_list: Vec<Value> = serde_json::from_str(&body).expect("Couldn't parse request");
 
     // This is really ugly, should improve the deserialization later
     for r in roster_list {
@@ -388,7 +388,7 @@ pub async fn fetch_matchups(db_pool: &db::DBPool, league_id: String) -> Result<(
         .unwrap();
 
     let season: i32 = 2022;//time[0].get("season");
-    let week: i32 = 10;//time[0].get("week");
+    let week: i32 = 12;//time[0].get("week");
 
     let body = reqwest::get(format!("https://api.sleeper.app/v1/league/{}/matchups/{}", league_id, week))
         .await

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -36,3 +36,13 @@
 .bl-navbar {
     margin-bottom: 5rem;
 }
+
+.bracket-avatar {
+    height: 5rem;
+    width: 5rem;
+    border-radius: 5rem;
+}
+
+.bracket-list {
+    list-style-type: none;
+}

--- a/templates/bracket.html
+++ b/templates/bracket.html
@@ -1,0 +1,18 @@
+{% if bracket.num_teams > 0 %} {# Skip showing bracket if there are no teams #}
+<div class="row">
+    {% for stage in bracket.stages -%}
+    <div class="col">
+        <ul class="bracket-list">
+            <h3>Week {{ bracket.start_week + loop.index0 }}</h3>
+        {% for team in stage -%}
+            <li>
+                <div>
+                    ({{ team.rank }}) - <img class="bracket-avatar" src="https://sleepercdn.com/avatars/{{ team.user.avatar }}" /><a href="/user/{{ team.user.id }}">{{ team.user.name }}</a>: {{ team.points | round(precision=2)}}
+                </div>
+            </li>
+        {%- endfor %}
+        </ul>
+    </div>
+    {%- endfor %}
+</div>
+{% endif %}

--- a/templates/standings.html
+++ b/templates/standings.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     {% include "header.html" %}
+    {% include "bracket.html" %}
     <div>
         <div>
             <table>


### PR DESCRIPTION
Implements a playoff system and bracket on the standings page. Currently it only supports "at large bids", that is it can only consider the top `n` overall teams for the playoffs. It might be desired to pull the top `m` teams from _each_ league.

Visually the bracket also needs work, however, that should be done during an overall visual update later.

Finishes #3